### PR TITLE
Version bump, update README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,29 @@
-# 0.12.2 - 11-09-2019
+# 0.12.3 - 2020-10-15
+
+- Fixes a problem where scheduler didn't recover from Redis flush
+
+# 0.12.2 - 2019-09-11
 
 - Allow sorting schedule history by schedule name
 
-# 0.12.1 - 30-08-2019
+# 0.12.1 - 2019-08-30
 
 - Jobs that change family from per host to non per host can cause a tight loop
 
-# 0.12.0 - 29-08-2019
+# 0.12.0 - 2019-08-29
 
 - Add support for multiple workers which allows avoiding queue starvation
 
-# 0.11.0 - 24-06-2019
+# 0.11.0 - 2019-06-24
 
 - Correct situation where distributed mutex could end in a tight loop when
  redis could not be contacted
 
-# 0.9.2 - 26-04-2019
+# 0.9.2 - 2019-04-26
 
 - Correct UI so it displays durations that are longer than a minute
 
-# 0.9.1 - 21-01-2019
+# 0.9.1 - 2019-01-21
 
 - Remove dependency on ActiveSupport and add proper dependency for Sidekiq
 - Remove Discourse specific bits from Sidekiq web scheduler tab.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/discourse/mini_scheduler.svg?branch=master)](https://travis-ci.org/discourse/mini_scheduler)
+[![Build Status](https://github.com/discourse/mini_scheduler/workflows/CI/badge.svg)](https://github.com/discourse/mini_scheduler/actions)
 [![Gem Version](https://badge.fury.io/rb/mini_scheduler.svg)](https://rubygems.org/gems/mini_scheduler)
 
 # mini_scheduler


### PR DESCRIPTION
* Switches badge in README from Travis to GitHub Actions
* Updates the date format in CHANGELOG to ISO 8601 for better readability.
* Version bump