### PR TITLE
DEV: Update workflow, clean up, enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'bundler'
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+
     strategy:
       matrix:
         ruby:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,37 +21,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Redis
-        uses: shogo82148/actions-setup-redis@v1
-        with:
-          redis-version: '5.x'
-
-      - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
 
-      - name: Setup bundler
-        run: |
-          gem install bundler --no-doc
-          bundle config path vendor/bundle
-
-      - name: Bundler cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-
-      - name: Setup gems
-        run: bundle install --jobs 4
-
-      - name: Rubocop
+      - name: Lint
         run: bundle exec rubocop
 
-      - name: RSpec
-        run: bundle exec rspec
+      - name: Tests
+        run: bundle exec rake test
 
   publish:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,1 @@
-/.bundle/
-/.yardoc
-/_yardoc/
-/coverage/
-/doc/
-/pkg/
-/spec/reports/
-/tmp/
 Gemfile.lock
-.DS_Store
-*.swp

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-git_source(:github) { 'https://github.com/discourse/mini_scheduler' }
-
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,7 @@ rescue Bundler::BundlerError => error
 end
 
 RSpec::Core::RakeTask.new(:spec)
+task test: :spec
 
 desc "Default: run tests"
 task default: [ :spec ]

--- a/lib/mini_scheduler/manager.rb
+++ b/lib/mini_scheduler/manager.rb
@@ -344,9 +344,9 @@ module MiniScheduler
       schedules
     end
 
-    @mutex = Mutex.new
+    @class_mutex = Mutex.new
     def self.seq
-      @mutex.synchronize do
+      @class_mutex.synchronize do
         @i ||= 0
         @i += 1
       end

--- a/mini_scheduler.gemspec
+++ b/mini_scheduler.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-rspec"
-  spec.add_development_dependency "mock_redis"
+  spec.add_development_dependency "redis"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rubocop-discourse", "~> 2.4.1"
 end

--- a/mini_scheduler.gemspec
+++ b/mini_scheduler.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files`.split($/).reject { |s| s =~ /^(spec|\.)/ }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sidekiq", ">= 4.2.3"
+  spec.add_runtime_dependency "sidekiq", ">= 4.2.3"
 
   spec.add_development_dependency "pg", ">= 1.0"
   spec.add_development_dependency "activesupport", ">= 5.2"

--- a/mini_scheduler.gemspec
+++ b/mini_scheduler.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/discourse/mini_scheduler"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = ">= 2.5.0"
+
   spec.files = `git ls-files`.split($/).reject { |s| s =~ /^(spec|\.)/ }
   spec.require_paths = ["lib"]
 

--- a/mini_scheduler.gemspec
+++ b/mini_scheduler.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency "mock_redis"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency 'rubocop-discourse'
+  spec.add_development_dependency "rubocop-discourse", "~> 2.4.1"
 end

--- a/mini_scheduler.gemspec
+++ b/mini_scheduler.gemspec
@@ -20,15 +20,15 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files`.split($/).reject { |s| s =~ /^(spec|\.)/ }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "sidekiq", ">= 4.2.3"
+  spec.add_runtime_dependency "sidekiq", ">= 4.2.3", "< 7.0"
 
-  spec.add_development_dependency "pg", ">= 1.0"
-  spec.add_development_dependency "activesupport", ">= 5.2"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "mocha"
-  spec.add_development_dependency "guard"
-  spec.add_development_dependency "guard-rspec"
-  spec.add_development_dependency "redis"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rubocop-discourse", "~> 2.4.1"
+  spec.add_development_dependency "pg", "~> 1.0"
+  spec.add_development_dependency "activesupport", "~> 6.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "mocha", "~> 1.0"
+  spec.add_development_dependency "guard", "~> 2.0"
+  spec.add_development_dependency "guard-rspec", "~> 4.0"
+  spec.add_development_dependency "redis", "~> 4.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rubocop-discourse", "= 2.4.1"
 end

--- a/mini_scheduler.gemspec
+++ b/mini_scheduler.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/discourse/mini_scheduler"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.files = `git ls-files`.split($/).reject { |s| s =~ /^(spec|\.)/ }
   spec.require_paths = ["lib"]

--- a/spec/mini_scheduler/manager_spec.rb
+++ b/spec/mini_scheduler/manager_spec.rb
@@ -67,7 +67,7 @@ describe MiniScheduler::Manager do
     MiniScheduler::Manager.new(enable_stats: false)
   }
 
-  let(:redis) { MockRedis.new }
+  let(:redis) { Redis.new }
 
   before do
 
@@ -128,6 +128,8 @@ describe MiniScheduler::Manager do
     wait_for(on_fail: on_thread_mismatch) do
       @thread_count == Thread.list.count
     end
+
+    redis.flushdb
   end
 
   it 'can disable stats' do

--- a/spec/mini_scheduler/schedule_info_spec.rb
+++ b/spec/mini_scheduler/schedule_info_spec.rb
@@ -4,7 +4,7 @@
 describe MiniScheduler::ScheduleInfo do
 
   let(:manager) { MiniScheduler::Manager.new }
-  let(:redis) { MockRedis.new }
+  let(:redis) { Redis.new }
 
   before do
     MiniScheduler.configure do |config|

--- a/spec/mini_scheduler/slow_spec.rb
+++ b/spec/mini_scheduler/slow_spec.rb
@@ -41,7 +41,7 @@ if ENV["SLOW"]
 
   describe MiniScheduler::Manager do
 
-    let(:redis) { MockRedis.new }
+    let(:redis) { Redis.new }
 
     it "can correctly operate with multiple workers" do
       MiniScheduler.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'mock_redis'
 require 'mini_scheduler'
 require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/integer/time'


### PR DESCRIPTION
Included:

* DEV: Add required_ruby_version
* DEV: Use `add_runtime_dependency`
* DEV: Specify rubocop-discourse version
* DEV: Add `rake test` task
* DEV: Update the CI workflow
* DEV: Rename class-level `@mutex`
* DEV: Remove git_source from Gemfile
* DEV: Replace mock_redis with actual redis
  Fixes flaky specs that were failing because mock_redis isn't thread-safe.
* DEV: Clean up .gitignore
* DEV: Prepare dependency versions for dependabot
* DEV: Add dependabot config