### PR TITLE
fix Sidekiq 6.5 compatability

### DIFF
--- a/lib/generators/mini_scheduler/install/templates/mini_scheduler_initializer.rb
+++ b/lib/generators/mini_scheduler/install/templates/mini_scheduler_initializer.rb
@@ -6,7 +6,7 @@ MiniScheduler.configure do |config|
   # config.redis = $redis
 
   # Define a custom exception handler when an exception is raised
-  # by a scheduled job. By default, SidekiqExceptionHandler is used.
+  # by a scheduled job. By default, Sidekiq.handle_exception is used.
 
   # config.job_exception_handler do |ex, context|
   #   ...

--- a/lib/mini_scheduler.rb
+++ b/lib/mini_scheduler.rb
@@ -4,16 +4,12 @@ require 'mini_scheduler/schedule'
 require 'mini_scheduler/schedule_info'
 require 'mini_scheduler/manager'
 require 'mini_scheduler/distributed_mutex'
-require 'sidekiq/exception_handler'
+require 'sidekiq'
 
 module MiniScheduler
 
   def self.configure
     yield self
-  end
-
-  class SidekiqExceptionHandler
-    extend Sidekiq::ExceptionHandler
   end
 
   def self.job_exception_handler(&blk)
@@ -25,7 +21,7 @@ module MiniScheduler
     if job_exception_handler
       job_exception_handler.call(ex, context)
     else
-      SidekiqExceptionHandler.handle_exception(ex, context)
+      Sidekiq.handle_exception(ex, context)
     end
   end
 

--- a/mini_scheduler.gemspec
+++ b/mini_scheduler.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files`.split($/).reject { |s| s =~ /^(spec|\.)/ }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sidekiq", ">= 4.2.3"
+  spec.add_dependency "sidekiq", ">= 6.5.0"
 
   spec.add_development_dependency "pg", ">= 1.0"
   spec.add_development_dependency "activesupport", ">= 5.2"

--- a/spec/mini_scheduler/manager_spec.rb
+++ b/spec/mini_scheduler/manager_spec.rb
@@ -294,13 +294,13 @@ describe MiniScheduler::Manager do
 
     context 'with default handler' do
       before do
-        MiniScheduler::SidekiqExceptionHandler.stubs(:handle_exception).with { |ex, ctx|
+        Sidekiq.stubs(:handle_exception).with { |ex, ctx|
           expect_job_failure(ex, ctx)
         }
       end
 
       after do
-        MiniScheduler::SidekiqExceptionHandler.unstub(:handle_exception)
+        Sidekiq.unstub(:handle_exception)
       end
 
       it 'captures failed jobs' do


### PR DESCRIPTION
`Sidekiq::ExceptionHandler` is not available anymore in Sidekiq 6.5.0.

This bumps the mininmal dependency for Sidekiq to v6.5.0, and drops `MiniScheduler::SidekiqExceptionHandler` (in favour of calling `Sidekiq.handle_exception` directly). I have not touched `MiniScheduler::VERSION`.

~~I can't seem to execute the test suite, `bundle exec rspec` gives me a lot of `NameError: uninitialized constant MiniScheduler::Manager::SecureRandom`, hence this is marked WIP. I'm hoping the specs run Github Actions.~~