### PR TITLE
FIX: Handle Redis failure during jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.15.0 - 2022-11-08
+# 0.15.0 - 2022-11-17
 
 - Fix data inconsistencies when Redis fails during jobs (#19)
 - Update minimum Ruby version to 2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.15.0 - 2022-11-08
+
+- Fix data inconsistencies when Redis fails during jobs (#19)
+- Update minimum Ruby version to 2.7
+
 # 0.14.0 - 2022-06-20
 
 - Fix compatibility with Sidekiq 6.5 (#15)

--- a/lib/mini_scheduler/manager.rb
+++ b/lib/mini_scheduler/manager.rb
@@ -386,6 +386,7 @@ module MiniScheduler
 
     @@identity_key_mutex = Mutex.new
     def identity_key
+      return @identity_key if @identity_key
       @@identity_key_mutex.synchronize do
         @identity_key ||= "_scheduler_#{hostname}:#{Process.pid}:#{self.class.seq}:#{SecureRandom.hex}"
       end

--- a/lib/mini_scheduler/manager.rb
+++ b/lib/mini_scheduler/manager.rb
@@ -37,19 +37,19 @@ module MiniScheduler
       def keep_alive(*ids)
         @manager.keep_alive(*ids)
       rescue => ex
-        MiniScheduler.handle_job_exception(ex, message: "Scheduling manager keep-alive")
+        MiniScheduler.handle_job_exception(ex, message: "Error during MiniScheduler keep)alive")
       end
 
       def repair_queue
         @manager.repair_queue
       rescue => ex
-        MiniScheduler.handle_job_exception(ex, message: "Scheduling manager queue repair")
+        MiniScheduler.handle_job_exception(ex, message: "Error during MiniScheduler repair_queue")
       end
 
       def reschedule_orphans
         @manager.reschedule_orphans!
       rescue => ex
-        MiniScheduler.handle_job_exception(ex, message: "Scheduling manager orphan rescheduler")
+        MiniScheduler.handle_job_exception(ex, message: "Error during MiniScheduler reschedule_orphans")
       end
 
       def ensure_worker_threads
@@ -59,7 +59,7 @@ module MiniScheduler
           @threads << Thread.new { worker_loop }
         end
       rescue => ex
-        MiniScheduler.handle_job_exception(ex, message: "Scheduling manager worker thread starter")
+        MiniScheduler.handle_job_exception(ex, message: "Error during MiniScheduler ensure_worker_threads")
       end
 
       def worker_loop
@@ -69,7 +69,7 @@ module MiniScheduler
           begin
             process_queue
           rescue => ex
-            MiniScheduler.handle_job_exception(ex, message: "Processing scheduled job queue")
+            MiniScheduler.handle_job_exception(ex, message: "Error during MiniScheduler worker_loop")
             break # Data could be in a bad state - stop the thread
           end
         end
@@ -121,7 +121,7 @@ module MiniScheduler
 
           klass.new.perform
         rescue => e
-          MiniScheduler.handle_job_exception(e, message: "Running a scheduled job", job: { "class" => klass })
+          MiniScheduler.handle_job_exception(e, message: "Error while running a scheduled job", job: { "class" => klass })
 
           error = "#{e.class}: #{e.message} #{e.backtrace.join("\n")}"
           failed = true

--- a/lib/mini_scheduler/version.rb
+++ b/lib/mini_scheduler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MiniScheduler
-  VERSION = "0.14.0"
+  VERSION = "0.15.0"
 end

--- a/spec/mini_scheduler/manager_spec.rb
+++ b/spec/mini_scheduler/manager_spec.rb
@@ -232,7 +232,7 @@ describe MiniScheduler::Manager do
       # Wait until the worker dies due to the redis failure
       wait_for(timeout: 5) { worker_threads.reject(&:alive?).count == 1 }
 
-      # Observe the broken status
+      # Observe that the status in Redis is stuck on "running"
       expect(manager.schedule_info(Testing::SuperLongJob).prev_result).to eq("RUNNING")
 
       # Redis back online

--- a/spec/mini_scheduler/manager_spec.rb
+++ b/spec/mini_scheduler/manager_spec.rb
@@ -208,6 +208,58 @@ describe MiniScheduler::Manager do
       manager.stop!
     end
 
+    it 'should recover from redis readonly within same manager instance' do
+      info = manager.schedule_info(Testing::SuperLongJob)
+      info.next_run = Time.now.to_i - 1
+      info.write!
+
+      manager.tick
+
+      wait_for do
+        manager.schedule_info(Testing::SuperLongJob).prev_result == "RUNNING"
+      end
+
+      # Simualate redis failure while job is running
+      MiniScheduler::ScheduleInfo.any_instance.stubs(:write!).raises(Redis::CommandError)
+
+      runner = manager.instance_variable_get(:@runner)
+      worker_threads = runner.instance_variable_get(:@threads)
+      worker_thread_ids = runner.worker_thread_ids
+
+      # Now that Redis is broken, simulate the 'SuperLongJob' ending
+      worker_threads.each(&:wakeup)
+
+      # Wait until the worker dies due to the redis failure
+      wait_for(timeout: 5) { worker_threads.reject(&:alive?).count == 1 }
+
+      # Observe the broken status
+      expect(manager.schedule_info(Testing::SuperLongJob).prev_result).to eq("RUNNING")
+
+      # Redis back online
+      MiniScheduler::ScheduleInfo.any_instance.unstub(:write!)
+
+      # Reschedule should not do anything straight away
+      manager.reschedule_orphans!
+      expect(manager.schedule_info(Testing::SuperLongJob).prev_result).to eq("RUNNING")
+
+      # Simultate time passing and redis keys expiring
+      worker_thread_ids.each do |id|
+        expect(manager.redis.ttl(id)).to be > 30
+        manager.redis.del(id)
+      end
+
+      manager.reschedule_orphans!
+
+      info = manager.schedule_info(Testing::SuperLongJob)
+      expect(info.prev_result).to eq("ORPHAN")
+      expect(info.next_run).to be <= Time.now.to_i
+
+      runner.instance_variable_get(:@recovery_thread).wakeup
+      manager.tick
+
+      wait_for { manager.schedule_info(Testing::SuperLongJob).prev_result == "RUNNING" }
+    end
+
     def queued_jobs(manager, with_hostname:)
       hostname = with_hostname ? manager.hostname : nil
       key = MiniScheduler::Manager.queue_key(manager.queue, hostname)

--- a/spec/mini_scheduler/manager_spec.rb
+++ b/spec/mini_scheduler/manager_spec.rb
@@ -341,7 +341,7 @@ describe MiniScheduler::Manager do
     def expect_job_failure(ex, ctx)
       expect(ex).to be_kind_of ZeroDivisionError
       expect(ctx).to match({
-        message: "Running a scheduled job",
+        message: "Error while running a scheduled job",
         job: { "class" => Testing::FailingJob },
       })
     end

--- a/spec/mini_scheduler/manager_spec.rb
+++ b/spec/mini_scheduler/manager_spec.rb
@@ -219,7 +219,7 @@ describe MiniScheduler::Manager do
         manager.schedule_info(Testing::SuperLongJob).prev_result == "RUNNING"
       end
 
-      # Simualate redis failure while job is running
+      # Simulate redis failure while job is running
       MiniScheduler::ScheduleInfo.any_instance.stubs(:write!).raises(Redis::CommandError)
 
       runner = manager.instance_variable_get(:@runner)
@@ -242,7 +242,7 @@ describe MiniScheduler::Manager do
       manager.reschedule_orphans!
       expect(manager.schedule_info(Testing::SuperLongJob).prev_result).to eq("RUNNING")
 
-      # Simultate time passing and redis keys expiring
+      # Simulate time passing and redis keys expiring
       worker_thread_ids.each do |id|
         expect(manager.redis.ttl(id)).to be > 30
         manager.redis.del(id)

--- a/spec/mini_scheduler/schedule_info_spec.rb
+++ b/spec/mini_scheduler/schedule_info_spec.rb
@@ -16,7 +16,7 @@ describe MiniScheduler::ScheduleInfo do
     manager.stop!
   end
 
-  context "every" do
+  describe "every" do
     class RandomJob
       extend ::MiniScheduler::Schedule
 
@@ -64,7 +64,7 @@ describe MiniScheduler::ScheduleInfo do
     end
   end
 
-  context "daily" do
+  describe "daily" do
 
     class DailyJob
       extend ::MiniScheduler::Schedule

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,10 @@ require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/integer/time'
 require 'mocha/api'
 
-def wait_for(on_fail: nil, &blk)
+def wait_for(on_fail: nil, timeout: 1, &blk)
   i = 0
   result = false
-  while !result && i < 1000
+  while !result && i < timeout * 1000
     result = blk.call
     i += 1
     sleep 0.001


### PR DESCRIPTION
MiniScheduler was previously able to detect 'orphaned' jobs when the entire `MiniScheduler::Manager` failed (e.g. a process restart). However, if something went wrong with the Redis connection during a job, the worker thread would be unable to remove the "RUNNING" status, and the job would be stuck in that state until its next scheduled run.

This commit makes a few changes to fix this:
- give each thread its own id, and use an expiring redis key to track its lifetime
- when changing a job to the 'RUNNING' state, update its `current_owner` from the manager's id to the worker thread's id. This ensures that the existing orphan-detection logic will pick up the job if the thread dies.
- ensure worker threads die when there is an internal mini_scheduler exception which could cause inconsistent job state
- automatically start new worker threads when existing ones die