### PR TITLE
FEATURE: Add `MiniScheduler::Manager.discover_running_scheduled_jobs` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.17.0 - 2024-08-06
+
+- Add `MiniScheduler::Manager.discover_running_scheduled_jobs` API to allow running scheduled jobs to easily be discovered on the
+  current host.
+
 # 0.16.0 - 2023-05-17
 
 - Support Redis gem version 5
@@ -14,7 +19,7 @@
 # 0.13.0 - 2020-11-30
 
 - Fix exception code so it has parity with Sidekiq 4.2.3 and up, version bump cause
-minimum version of Sikekiq changed.
+  minimum version of Sikekiq changed.
 
 # 0.12.3 - 2020-10-15
 
@@ -35,7 +40,7 @@ minimum version of Sikekiq changed.
 # 0.11.0 - 2019-06-24
 
 - Correct situation where distributed mutex could end in a tight loop when
- redis could not be contacted
+  redis could not be contacted
 
 # 0.9.2 - 2019-04-26
 

--- a/lib/mini_scheduler/version.rb
+++ b/lib/mini_scheduler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MiniScheduler
-  VERSION = "0.16.0"
+  VERSION = "0.17.0"
 end


### PR DESCRIPTION
This commit adds the `MiniScheduler::Manager.discover_running_scheduled_jobs`
method which returns an array of all currently running scheduled jobs
for the current host.

### Reviewer notes

This helps to simplify the `discourse-prometheus` plugin by not leaking out internal details: https://github.com/discourse/discourse-prometheus/pull/101

Also this new API enables us to log the thread's backtrace of stuck scheduled jobs: https://github.com/discourse/discourse/pull/28258