### PR TITLE
Add support for Sidekiq 7+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - sidekiq-7
 
 jobs:
   lint:
@@ -28,18 +29,24 @@ jobs:
           bundle exec stree check Gemfile $(git ls-files '*.rb') $(git ls-files '*.rake') $(git ls-files '*.thor')
 
   test:
+    name: Ruby ${{ matrix.ruby }}, Sidekiq ${{ matrix.sidekiq }}, ${{ matrix.redis }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     services:
       redis:
-        image: redis
+        image: ${{ matrix.redis }}
         ports:
           - 6379:6379
 
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "3.3"]
+        ruby:    ["3.0", "3.1", "3.2", "3.3"]
+        redis:   ["redis", "valkey/valkey"]
+        sidekiq: ["6.5", "7.0", "7.1", "7.2", "7.3"]
+
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/sidekiq-${{ matrix.sidekiq }}.gemfile
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# next
+
+- Remove support for Sidekiq < 6.5
+- Update minimum Ruby version to 3.0
+
 # 0.17.0 - 2024-08-06
 
 - Add `MiniScheduler::Manager.discover_running_scheduled_jobs` API to allow running scheduled jobs to easily be discovered on the

--- a/gemfiles/sidekiq-6.5.gemfile
+++ b/gemfiles/sidekiq-6.5.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "sidekiq", "~> 6.5.0"

--- a/gemfiles/sidekiq-7.0.gemfile
+++ b/gemfiles/sidekiq-7.0.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "sidekiq", "~> 7.0.0"

--- a/gemfiles/sidekiq-7.1.gemfile
+++ b/gemfiles/sidekiq-7.1.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "sidekiq", "~> 7.1.0"

--- a/gemfiles/sidekiq-7.2.gemfile
+++ b/gemfiles/sidekiq-7.2.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "sidekiq", "~> 7.2.0"

--- a/gemfiles/sidekiq-7.3.gemfile
+++ b/gemfiles/sidekiq-7.3.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "sidekiq", "~> 7.3.0"

--- a/lib/mini_scheduler/manager.rb
+++ b/lib/mini_scheduler/manager.rb
@@ -394,10 +394,10 @@ module MiniScheduler
         begin
           require "socket"
           Socket.gethostname
-        rescue => e
+        rescue StandardError
           begin
             `hostname`.strip
-          rescue => e
+          rescue StandardError
             "unknown_host"
           end
         end

--- a/mini_scheduler.gemspec
+++ b/mini_scheduler.gemspec
@@ -15,12 +15,12 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/discourse/mini_scheduler"
   spec.license = "MIT"
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.files = `git ls-files`.split($/).reject { |s| s =~ /^(spec|\.)/ }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "sidekiq", ">= 4.2.3", "< 7.0"
+  spec.add_runtime_dependency "sidekiq", ">= 6.5", "< 8.0"
 
   spec.add_development_dependency "pg", "~> 1.0"
   spec.add_development_dependency "activesupport", "~> 7.0"


### PR DESCRIPTION
This primarily adds support for Sidekiq 7.

The [support policy for Sidekiq][1] states that the previous major releases is supported "as long as they are less than five years old". With Sidekiq 6.0 released in August 2019, that time has come. Despite of this, I'm keeping support for 6.5 because that is the latest version users of `mini_scheduler` are using. This should allow them updating `mini_scheduler` before they tackle upgrading to Sidekiq 7.

This also adds an exhaustive test matrix covering
- Ruby 3.0..3.3
- Sidekiq 6.5..7.3
- official Redis server and its ValKey fork

Testing against ValKey ensures smooth transitioning from the [proprietary Redis 7.2][2] to a [pure Open Source stack][3].

[1]: https://github.com/sidekiq/sidekiq/wiki/Commercial-Support
[2]: https://redis.io/legal/licenses/
[3]: https://github.com/valkey-io/valkey?tab=License-1-ov-file#readme