### PR TITLE
Fix MiniScheduler::Web integration with Sidekiq 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+gemfiles/*.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
 - Fix `MiniScheduler::Web` integration in Sidekiq 8+
+- Move `redis` import to specs, host application won't need to explicitly
+  declare an otherwise unnecessary dependency (Sidekiq already migrated
+  to `redis-client` in v7.0)
 
 # 0.19.0 - 2026-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Fix `MiniScheduler::Web` integration in Sidekiq 8+
+
 # 0.19.0 - 2026-03-30
 
 - Fix race condition in `MiniScheduler::Manager`

--- a/lib/mini_scheduler.rb
+++ b/lib/mini_scheduler.rb
@@ -5,7 +5,6 @@ require "mini_scheduler/schedule_info"
 require "mini_scheduler/manager"
 require "mini_scheduler/distributed_mutex"
 require "sidekiq"
-require "redis"
 
 begin
   require "sidekiq/exception_handler"

--- a/lib/mini_scheduler/web.rb
+++ b/lib/mini_scheduler/web.rb
@@ -18,22 +18,24 @@ module MiniScheduler
       end
     end
 
-    def self.registered(app)
-      app.helpers do
-        def sane_time(time)
-          return unless time
-          time
-        end
+    module Helpers
+      def sane_time(time)
+        return unless time
+        time
+      end
 
-        def sane_duration(duration)
-          return unless duration
-          if duration < 1000
-            "#{duration}ms"
-          else
-            "#{"%.2f" % (duration / 1000.0)} secs"
-          end
+      def sane_duration(duration)
+        return unless duration
+        if duration < 1000
+          "#{duration}ms"
+        else
+          "#{"%.2f" % (duration / 1000.0)} secs"
         end
       end
+    end
+
+    def self.registered(app)
+      app.helpers Helpers
 
       app.get "/scheduler" do
         MiniScheduler.before_sidekiq_web_request&.call
@@ -72,5 +74,18 @@ module MiniScheduler
   end
 end
 
-Sidekiq::Web.register(MiniScheduler::Web)
-Sidekiq::Web.tabs["Scheduler"] = "scheduler"
+sidekiq_version = Gem::Version.new(Sidekiq::VERSION)
+register_options = {
+  name: nil, # asset namespace (not used here)
+  tab: "Scheduler", # tab label
+  index: "scheduler", # index route name
+}
+
+if sidekiq_version < "7.3.0"
+  Sidekiq::Web.register MiniScheduler::Web
+  Sidekiq::Web.tabs[register_options[:tab]] = register_options[:index]
+elsif sidekiq_version < "8.0.0"
+  Sidekiq::Web.register(MiniScheduler::Web, **register_options)
+else # 8.0+
+  Sidekiq::Web.configure { |cfg| cfg.register(MiniScheduler::Web, **register_options) }
+end

--- a/spec/mini_scheduler/web_spec.rb
+++ b/spec/mini_scheduler/web_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# encoding: utf-8
+
+require "sidekiq/web"
+require "mini_scheduler/web"
+
+describe MiniScheduler::Web do
+  it "registers with Sidekiq::Web" do
+    expect(Sidekiq::Web.tabs["Scheduler"]).to eq "scheduler"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require "active_support"
 require "active_support/core_ext/numeric/time"
 require "active_support/core_ext/integer/time"
 require "mocha/api"
+require "redis" # TODO: migrate to redis-client when removing support for Sidekiq 6.5
 
 def wait_for(on_fail: nil, timeout: 1, &blk)
   i = 0


### PR DESCRIPTION
This fixes two things:

1. `Sidekiq::Web.register` has changed a bit over time, and needs version-specific code to register the scheduler UI without deprecation warnings.

    The implementation with Sidekiq simply raises an `ArgumentError` since 1da8c20 due to missing required arguments. This is an oversight because the `mini_scheduler/web` just wasn't imported into the test suite. I have added a (very) rudimentary spec.

2. The `require "redis"` in `lib/mini_scheduler.rb` can cause a `LoadError` when the host application uses Sidekiq 7.0+ but not the Redis gem directly. Sidekiq migrated to `redis-client`.

   The current implementation *requires* host applications to explicitly declare the `redis` dependency. MiniScheduler uses it only in some specs, so I simply moved the import to the `spec_helper.rb`.